### PR TITLE
Enable extracting and running ViT

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -472,6 +472,44 @@ cc_binary(
 )
 
 cc_binary(
+    name = "image_tokenizer",
+    srcs = ["gemma/image_tokenizer.cc"],
+    deps = [
+        ":app",
+        ":args",
+        ":benchmark_helper",
+        ":common",
+        ":gemma_lib",
+        ":threading",
+        # Placeholder for internal dep, do not remove.,
+        "//compression:sfp",
+        "//paligemma:image",
+        "@highway//:hwy",
+        "@highway//:profiler",
+        "@highway//:thread_pool",
+    ],
+)
+
+cc_binary(
+    name = "vit_extractor",
+    srcs = ["gemma/vit_extractor.cc"],
+    deps = [
+        ":app",
+        ":args",
+        ":benchmark_helper",
+        ":common",
+        ":gemma_lib",
+        ":threading",
+        # Placeholder for internal dep, do not remove.,
+        "//compression:sfp",
+        "//paligemma:image",
+        "@highway//:hwy",
+        "@highway//:profiler",
+        "@highway//:thread_pool",
+    ],
+)
+
+cc_binary(
     name = "single_benchmark",
     srcs = ["evals/benchmark.cc"],
     deps = [

--- a/ViT.md
+++ b/ViT.md
@@ -1,0 +1,20 @@
+# Build and execute the ViT extractor
+```sh
+export PALIGEMMA_PATH=/path/to/paligemma
+bazel build -c opt --cxxopt=-std=c++20 //:vit_extractor
+bazel-bin/vit_extractor --weights ${PALIGEMMA_PATH}/paligemma-3b-mix-224-sfp.sbs --output ${PALIGEMMA_PATH}/vit.sbs
+```
+
+# Build and execute the tokenizer
+```sh
+export PALIGEMMA_PATH=/path/to/paligemma
+bazel build -c opt --cxxopt=-std=c++20 //:image_tokenizer
+bazel-bin/image_tokenizer --tokenizer ${PALIGEMMA_PATH}/paligemma_tokenizer.model --weights ${PALIGEMMA_PATH}/vit.sbs --image_file ${PALIGEMMA_PATH}/input.ppm --image_tokens_out ${PALIGEMMA_PATH}/input.tokens
+```
+
+# Build and run gemma with the image tokens only
+```sh
+export PALIGEMMA_PATH=/path/to/paligemma
+bazel build -c opt --cxxopt=-std=c++20 //:gemma
+bazel-bin/gemma --tokenizer ${PALIGEMMA_PATH}/paligemma_tokenizer.model --model paligemma-224 --weights ${PALIGEMMA_PATH}/paligemma-3b-mix-224-sfp.sbs --image_tokens_file ${PALIGEMMA_PATH}/input.tokens
+```

--- a/compression/compress.h
+++ b/compression/compress.h
@@ -165,7 +165,6 @@ class MatPtr {
 
   // Adds the blob to the writer.
   void AddToWriter(BlobWriter& writer) const {
-    fprintf(stderr, "Adding %s to writer\n", name_.c_str());
     writer.Add(MakeKey(name_.c_str()), ptr_, SizeBytes());
   }
 

--- a/gemma/common.cc
+++ b/gemma/common.cc
@@ -39,6 +39,7 @@ constexpr const char* kModelFlags[] = {
     "9b-pt", "9b-it",                // Gemma2 9B
     "27b-pt", "27b-it",              // Gemma2 27B
     "paligemma-224",                 // PaliGemma 224
+    "paligemma-224-vit",             // PaliGemma 224, ViT only
     "paligemma2-3b-224",             // PaliGemma2 3B 224
     "paligemma2-10b-224",            // PaliGemma2 10B 224
 };
@@ -51,6 +52,7 @@ constexpr Model kModelTypes[] = {
     Model::GEMMA2_9B, Model::GEMMA2_9B,    // Gemma2 9B
     Model::GEMMA2_27B, Model::GEMMA2_27B,  // Gemma2 27B
     Model::PALIGEMMA_224,                  // PaliGemma 224
+    Model::PALIGEMMA_224_VIT,              // PaliGemma 224, ViT only
     Model::PALIGEMMA2_3B_224,              // PaliGemma2 3B 224
     Model::PALIGEMMA2_10B_224,             // PaliGemma2 10B 224
 };
@@ -63,6 +65,7 @@ constexpr ModelTraining kModelTraining[] = {
     ModelTraining::GEMMA_PT, ModelTraining::GEMMA_IT,  // Gemma2 9B
     ModelTraining::GEMMA_PT, ModelTraining::GEMMA_IT,  // Gemma2 27B
     ModelTraining::PALIGEMMA,                          // PaliGemma 224
+    ModelTraining::PALIGEMMA,                          // PaliGemma 224, ViT only
     ModelTraining::PALIGEMMA,                          // PaliGemma2 3B 224
     ModelTraining::PALIGEMMA,                          // PaliGemma2 10B 224
 };

--- a/gemma/configs.cc
+++ b/gemma/configs.cc
@@ -236,6 +236,16 @@ static ModelConfig ConfigPaliGemma_224() {
   return config;
 }
 
+static ModelConfig ConfigPaliGemma_224_ViT() {
+  ModelConfig config;
+  config.model_name = "PaliGemma_224_ViT";
+  config.model = Model::PALIGEMMA_224_VIT;
+  config.model_dim = 2048;
+  AddVitConfig(config);
+  config.vit_only = true;
+  return config;
+}
+
 ModelConfig VitConfig(const ModelConfig& config) {
   ModelConfig vit_config = ConfigNoSSM();
   vit_config.model_dim = config.vit_model_dim;
@@ -280,6 +290,8 @@ ModelConfig ConfigFromModel(Model model) {
       return ConfigGemmaTiny();
     case Model::PALIGEMMA_224:
       return ConfigPaliGemma_224();
+    case Model::PALIGEMMA_224_VIT:
+      return ConfigPaliGemma_224_ViT();
     case Model::PALIGEMMA2_3B_224:
       return ConfigPaliGemma2_3B_224();
     case Model::PALIGEMMA2_10B_224:

--- a/gemma/configs.h
+++ b/gemma/configs.h
@@ -114,6 +114,7 @@ enum class Model {
   GEMMA_TINY,
   GEMMA2_2B,
   PALIGEMMA_224,
+  PALIGEMMA_224_VIT,
   PALIGEMMA2_3B_224,
   PALIGEMMA2_10B_224,
 };
@@ -122,7 +123,8 @@ enum class Model {
 static constexpr Model kAllModels[] = {
     Model::GEMMA_2B, Model::GEMMA_7B, Model::GEMMA2_9B, Model::GEMMA2_27B,
     Model::GRIFFIN_2B, Model::GEMMA_TINY, Model::GEMMA2_2B,
-    Model::PALIGEMMA_224, Model::PALIGEMMA2_3B_224, Model::PALIGEMMA2_10B_224,
+    Model::PALIGEMMA_224, Model::PALIGEMMA_224_VIT,
+    Model::PALIGEMMA2_3B_224, Model::PALIGEMMA2_10B_224,
 };
 
 struct LayerConfig {
@@ -219,6 +221,7 @@ struct ModelConfig {
   // Dimensions related to image processing.
   size_t patch_width = 14;
   size_t image_size = 224;
+  bool vit_only = false;
 };
 
 // Returns the config for the given model.

--- a/gemma/image_tokenizer.cc
+++ b/gemma/image_tokenizer.cc
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+
+#include "evals/benchmark_helper.h"
+#include "util/args.h"  // HasHelp
+
+#if (!defined(HWY_VERSION_LT) || HWY_VERSION_LT(1, 2)) && !HWY_IDE
+#error "Please update to version 1.2 of github.com/google/highway."
+#endif
+#if HWY_CXX_LANG < 201703L
+#error "Gemma.cpp requires C++17, please pass -std=c++17."
+#endif
+
+namespace gcpp {
+
+class TokenizerArgs : public ArgsBase<TokenizerArgs> {
+ public:
+  TokenizerArgs(int argc, char* argv[]) { InitAndParse(argc, argv); }
+  // TODO(atv): Add weights path, tokenizer path
+  TokenizerArgs(const std::string& tokenizer_path,
+                const std::string& weights_path,
+                const std::string& image_file_path,
+                const std::string& image_tokens_out_path) {
+    Init();
+    tokenizer.path = tokenizer_path;
+    weights.path = weights_path;
+    image_file.path = image_file_path;
+    image_tokens_out.path = image_tokens_out_path;
+  }
+
+  const char* Validate() {
+    if (tokenizer.path.empty()) {
+        return "Missing --tokenizer flag.";
+    }
+    if (!tokenizer.Exists()) {
+        return "Can't open file specified with --tokenizer.";
+    }
+
+    if (weights.path.empty()) {
+        return "Missing --weights flag.";
+    }
+    if (!weights.Exists()) {
+        return "Can't open file specified with --weights.";
+    }
+
+    if (image_file.path.empty()) {
+        return "Missing --image_file flag.";
+    }
+    if (!image_file.Exists()) {
+        return "Can't open file specified with --image_file.";
+    }
+
+    if (image_tokens_out.path.empty()) {
+        return "Missing --image_tokens_out flag.";
+    }
+    return nullptr;
+  }
+
+  Path tokenizer;
+  Path weights;
+  Path image_file;
+  Path image_tokens_out;
+
+  template <class Visitor>
+  void ForEach(const Visitor& visitor) {
+    visitor(tokenizer, "tokenizer", Path(),
+            "Path name of tokenizer model file.\n Required.");
+    visitor(weights, "weights", Path(),
+            "Path name of weights model file.\n Required.");
+    visitor(image_file, "image_file", Path(),
+            "Path name of image file (.ppm).\n Required.");
+    visitor(image_tokens_out, "image_tokens_out", Path(),
+            "Path name of token output file.\n Required.");
+  }
+};
+
+void Run(TokenizerArgs& tokenizer) {
+    std::mt19937 gen;
+    InferenceArgs inference;
+    inference.deterministic = true;
+    InitGenerator(inference, gen);
+
+    AppArgs app;
+    NestedPools pools = CreatePools(app);
+    Allocator::Init(pools.Topology());
+
+    LoaderArgs loader(tokenizer.tokenizer.path, tokenizer.weights.path, "paligemma-224-vit");
+    loader.Validate();
+
+    Gemma model = CreateGemma(loader, pools);
+
+    Image image;
+    ImageTokens image_tokens;
+    image_tokens = ImageTokens(Extents2D(model.GetModelConfig().vit_seq_len, model.GetModelConfig().model_dim));
+    HWY_ASSERT(image.ReadPPM(tokenizer.image_file.path));
+    image.Resize();
+    RuntimeConfig runtime_config = {
+        .gen = &gen,
+        .verbosity = 1,
+        .use_spinning = Tristate::kDefault,
+    };
+    model.GenerateImageTokens(runtime_config, image, image_tokens);
+
+    if (!tokenizer.image_tokens_out.path.empty()) {
+      auto image_tokens_out_file = gcpp::OpenFileOrNull(tokenizer.image_tokens_out, "w+");
+      image_tokens_out_file->Write(image_tokens.All(), image_tokens.NumBytes(), 0);
+      fprintf(stderr,
+        "Wrote tokens to %s\n", tokenizer.image_tokens_out.path.c_str()
+      );
+    }
+}
+
+}  // namespace gcpp
+
+int main(int argc, char** argv) {
+    gcpp::TokenizerArgs tokenizer(argc, argv);
+
+    if (const char* error = tokenizer.Validate()) {
+      HWY_ABORT("\nInvalid args: %s", error);
+    }
+
+    gcpp::Run(tokenizer);
+
+    return 0;
+}

--- a/gemma/vit_extractor.cc
+++ b/gemma/vit_extractor.cc
@@ -1,0 +1,147 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+
+#include "evals/benchmark_helper.h"
+#include "util/args.h"  // HasHelp
+
+#if (!defined(HWY_VERSION_LT) || HWY_VERSION_LT(1, 2)) && !HWY_IDE
+#error "Please update to version 1.2 of github.com/google/highway."
+#endif
+#if HWY_CXX_LANG < 201703L
+#error "Gemma.cpp requires C++17, please pass -std=c++17."
+#endif
+
+namespace gcpp {
+
+class VitExtractorArgs : public ArgsBase<VitExtractorArgs> {
+ public:
+  VitExtractorArgs(int argc, char* argv[]) { InitAndParse(argc, argv); }
+  VitExtractorArgs(const std::string& weights_path, const std::string& output_path) {
+    Init();
+    weights.path = weights_path;
+    output.path = output_path;
+  }
+
+  const char* Validate() {
+    if (weights.path.empty()) {
+        return "Missing --weights flag.";
+    }
+    if (!weights.Exists()) {
+        return "Can't open file specified with --weights.";
+    }
+    if (output.path.empty()) {
+        return "Missing --output flag.";
+    }
+    return nullptr;
+  }
+
+  Path weights;
+  Path output;
+
+  template <class Visitor>
+  void ForEach(const Visitor& visitor) {
+    visitor(weights, "weights", Path(),
+            "Path name of weights model file.\n Required.");
+    visitor(output, "output", Path(),
+            "Path name out VIT output file.\n Required.");
+  }
+};
+
+// Storage for data copied from the original weights.
+std::vector<std::vector<uint8_t>> vit_data;
+void CopyByKey(BlobReader& reader, BlobWriter& writer, hwy::uint128_t key, size_t bytes, hwy::ThreadPool& pool, const Path& filename) {
+  auto& data = vit_data.emplace_back(bytes);
+  reader.ReadOne(key, data.data(), bytes);
+  writer.Add(key, data.data(), bytes);
+}
+
+void Run(VitExtractorArgs& extractor) {
+    AppArgs app;
+    NestedPools pools = CreatePools(app);
+    Allocator::Init(pools.Topology());
+    auto& pool = pools.Pool();
+
+    ModelWeightsStorage model;
+    ModelInfo info;
+    info.model = Model::PALIGEMMA_224;
+    info.weight = Type::kSFP;
+    model.Load(extractor.weights, info.model, info.weight, pools.Pool());
+
+    if (model.Config().vit_layer_configs.empty()) {
+        HWY_ABORT("No VIT layers in this model!");
+    }
+
+    ModelConfig vit_config = VitConfig(model.Config());
+    BlobReader vit_reader;
+    vit_reader.Open(extractor.weights);
+
+    BlobWriter vit_writer;
+
+    // Iterate over the ViT layers and copy out their data.
+    std::vector<LayerWeightsPtrs<SfpStream>*> vit_layers(vit_config.layer_configs.size());
+    for (size_t layer = 0; layer < vit_config.layer_configs.size(); ++layer) {
+        auto* layer_weights = model.GetWeightsOfType<SfpStream>()->GetVitLayer(layer);
+        vit_layers[layer] = layer_weights;
+        LayerWeightsPtrs<SfpStream>::ForEachTensor(vit_layers, layer, ForEachType::kIgnoreNulls,
+        [&](const char* name, hwy::Span<MatPtr*> tensors) {
+            auto tensor = tensors[0];
+            auto key = MakeKey(name);
+            CopyByKey(vit_reader, vit_writer, key, tensor->SizeBytes(), pool, extractor.output);
+        });
+    }
+
+    // Extract common ViT layers from the weights.
+    auto enc_norm_bias = model.GetWeightsOfType<SfpStream>()->vit_encoder_norm_bias;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Benc_norm_bias"), enc_norm_bias.SizeBytes(), pool, extractor.output);
+
+    auto enc_norm_scale = model.GetWeightsOfType<SfpStream>()->vit_encoder_norm_scale;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Benc_norm_scale"), enc_norm_scale.SizeBytes(), pool, extractor.output);
+
+    auto img_emb_bias = model.GetWeightsOfType<SfpStream>()->vit_img_embedding_bias;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Fimg_emb_bias"), img_emb_bias.SizeBytes(), pool, extractor.output);
+
+    auto img_emb_kernel = model.GetWeightsOfType<SfpStream>()->vit_img_embedding_kernel;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Bimg_emb_kernel"), img_emb_kernel.SizeBytes(), pool, extractor.output);
+
+    auto img_pos_emb = model.GetWeightsOfType<SfpStream>()->vit_img_pos_embedding;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Fimg_pos_emb"), img_pos_emb.SizeBytes(), pool, extractor.output);
+
+    auto img_head_bias = model.GetWeightsOfType<SfpStream>()->vit_img_head_bias;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Fimg_head_bias"), img_head_bias.SizeBytes(), pool, extractor.output);
+
+    auto img_head_kernel = model.GetWeightsOfType<SfpStream>()->vit_img_head_kernel;
+    CopyByKey(vit_reader, vit_writer, MakeKey("Bimg_head_kernel"), img_head_kernel.SizeBytes(), pool, extractor.output);
+
+    // Flush all extracted weights to the output file.
+    vit_writer.WriteAll(pools.Pool(), extractor.output);
+}
+
+}  // namespace gcpp
+
+int main(int argc, char** argv) {
+    gcpp::VitExtractorArgs extractor(argc, argv);
+
+    if (const char* error = extractor.Validate()) {
+      // gcpp::ShowHelp(loader, inference, app);
+      HWY_ABORT("\nInvalid args: %s", error);
+    }
+
+    gcpp::Run(extractor);
+
+    return 0;
+}

--- a/gemma/weights.h
+++ b/gemma/weights.h
@@ -490,8 +490,10 @@ struct ModelWeightsPtrs {
     int layer_idx = -1;
     char sep = ' ';
     int sep_index = -1;
-    GEMMA_CALL_FUNC(embedder_input_embedding);
-    GEMMA_CALL_FUNC(final_norm_scale);
+    if (!ptrs[0]->weights_config.vit_only) {
+      GEMMA_CALL_FUNC(embedder_input_embedding);
+      GEMMA_CALL_FUNC(final_norm_scale);
+    }
     if (ptrs[0]->weights_config.vit_layer_configs.size() > 0) {
       // Vit parts.
       GEMMA_CALL_FUNC(vit_encoder_norm_bias);

--- a/util/app.h
+++ b/util/app.h
@@ -226,6 +226,8 @@ struct InferenceArgs : public ArgsBase<InferenceArgs> {
   bool deterministic;
   bool multiturn;
   Path image_file;
+  Path image_tokens_out;
+  Path image_tokens_file;
 
   // Returns error string or nullptr if OK.
   const char* Validate() const {
@@ -257,6 +259,10 @@ struct InferenceArgs : public ArgsBase<InferenceArgs> {
             "  Default : 0 (conversation "
             "resets every turn)");
     visitor(image_file, "image_file", Path(), "Image file to load.");
+    visitor(image_tokens_out, "image_tokens_out", Path(),
+            "Path name to store image tokens.\n");
+    visitor(image_tokens_file, "image_tokens_file", Path(),
+            "Image tokens file to load.");
   }
 
   void CopyTo(RuntimeConfig& runtime_config) const {


### PR DESCRIPTION
- Add `vit_extractor`, which can take a PaliGemma model and extract only weights needed for executing the vision tokenizer.
- Add `image_tokenizer`, which uses the weights extracted by `vit_extractor`, to convert PPM images into PaliGemma tokens.
- Modify the main Gemma runtime to accept an `image_tokens_file` flag, which should point to a tokens file from `image_tokenizer`. The tokens will be used instead of generating new ones. Note: Only `image_tokens` OR `image_tokens_file` can be passed. Trying to use both at once is an error.